### PR TITLE
Fix extra parens in binary existential preprocessor

### DIFF
--- a/src/preprocessors/preprocessBinaryExistentialOperator.js
+++ b/src/preprocessors/preprocessBinaryExistentialOperator.js
@@ -16,12 +16,12 @@ export default function preprocessBinaryExistentialOperator(node, patcher) {
     if (node.left.type === 'Identifier') {
       // e.g. `a ? b` -> `if a? then a else b`
       //        ^^^           ^^^^^^^^^^^^^^
-      patcher.replace(node.left.range[1], node.right.range[0], `? then ${node.left.raw} else `);
+      patcher.replace(node.range[0], node.range[1], `${node.left.raw}? then ${node.left.raw} else ${node.right.raw}`);
     } else {
       let tmp = getFreeBinding(node.scope);
       // e.g. `@a ? @b` -> `if (ref = @a)? then ref else @b`
       //       ^^^^^           ^^^^^^^^^^^^^^^^^^^^^^^^^^
-      patcher.replace(node.left.range[0], node.right.range[0], `(${tmp} = ${node.left.raw})? then ${tmp} else `);
+      patcher.replace(node.range[0], node.range[1], `(${tmp} = ${node.left.raw})? then ${tmp} else ${node.right.raw}`);
     }
 
     return true;

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -1066,6 +1066,10 @@ describe('automatic conversions', function() {
       check(`a ? b`, `if ((typeof a !== "undefined" && a !== null)) { a; } else { b; }`);
     });
 
+    it('deals gracefully with extra parens in simple binary existential operators', function() {
+      check(`a ? (b)`, `if ((typeof a !== "undefined" && a !== null)) { a; } else { b; }`);
+    });
+
     it('handles complex binary existential operators', function() {
       check(
         `@a ? @b`,
@@ -1073,6 +1077,16 @@ describe('automatic conversions', function() {
         var ref;
         if (((ref = this.a) != null)) { ref; } else { this.b; }
       `);
+    });
+
+    it('deals gracefully with extra parens in complex binary existential operators', function() {
+      check(
+        `@a ? (@b)`,
+        `
+         var ref;
+         if (((ref = this.a) != null)) { ref; } else { this.b; }
+        `
+      );
     });
 
     it('prevents using temporary variables that clash with existing bindings', function() {


### PR DESCRIPTION
As these test-cases show, there can be extra parentheses within the `ExistsOp` node that do not belong to either the left or right nodes. So it's not safer to rewrite the whole node.