### PR TITLE
trimNodeRange in conditionals

### DIFF
--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -988,6 +988,22 @@ describe('automatic conversions', function() {
       `);
     });
 
+    it('works with `if` with immediate return', function() {
+      check(`
+        ->
+          if a
+            b
+        c
+      `,`
+        (function() {
+          if (a) {
+            return b;
+          }
+        });
+        c;
+      `);
+    });
+
     it('keeps single-line `if` statements on one line', function() {
       check(`if a then b`, `if (a) { b; }`);
     });


### PR DESCRIPTION
If you have a function that ends with a conditional, the close-of-function `})` can get written before the close-of-conditional `}`, due to the fact that functions trim trailing whitespace and conditionals do not.

This adds trimming to conditionals. It's possible that other block forms suffer the same bug and will also need to start trimming in case they appear at the end of a function.