### PR TITLE
Patch over buggy fixRange behavior

### DIFF
--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -70,10 +70,12 @@ function fixRange(node, map, source) {
       );
     }
   }
-
   const fixed = map.getOffset(node.line - 1, node.column - 1);
-  if (source.slice(fixed, fixed + node.raw.length) === node.raw) {
-    node.range = [fixed, fixed + node.raw.length];
+  for (var slide = 0; slide < 3; slide++) {
+    if (source.slice(fixed - slide, fixed - slide + node.raw.length) === node.raw) {
+      node.range = [fixed - slide, fixed - slide + node.raw.length];
+      break;
+    }
   }
 
   if (!node.range || node.raw !== source.slice(node.range[0], node.range[1])) {

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -1138,6 +1138,14 @@ describe('automatic conversions', function() {
         if ((typeof a !== "undefined" && a !== null) ? a.b : undefined) { c; }
       `);
     });
+
+    it('', function() {
+      check(`
+         (-> 42).observes('model')
+      `, `
+         (function() { return 42; }).observes('model');
+      `);
+    });
   });
 
   function check(source, expected) {


### PR DESCRIPTION
This closes #26. Unlike the other three PRs I just filed, this one is kinda hacky. :stuck_out_tongue_winking_eye: 

I don't fully understand fixRange, other than to see that it's trying to patch over problems in coffeescript redux. But I can see that it is failing due to off-by-one-or-two errors, so this patches over the problem by doing a little search for the correct piece of original sourcecode.

This was a necessary bandaid so I could make progress for now. But others may also find it helpful.