### PR TITLE
Fix return of interpolated string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ export function convert(source) {
   }
 
   traverse(ast, (node, descend) => {
+    patchReturns(node, patcher);
     patchKeywords(node, patcher);
     patchThis(node, patcher);
     patchPrototypeAccess(node, patcher);
@@ -58,7 +59,6 @@ export function convert(source) {
     patchCallOpening(node, patcher);
     patchObjectBraceOpening(node, patcher);
     patchDeclarations(node, patcher);
-    patchReturns(node, patcher);
     patchFunctionStart(node, patcher);
     patchClassStart(node, patcher);
     patchEquality(node, patcher);

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -517,6 +517,10 @@ describe('automatic conversions', function() {
     it('rewrites interpolations with spaces after the "{"', function() {
       check('"a#{ b }c"', '`a${ b }c`;');
     });
+
+    it('can return interpolated strings', function() {
+      check(`-> "#{a}"`, `(function() { return \`\${a}\`; });`);
+    });
   });
 
   describe('adding semi-colons', function() {


### PR DESCRIPTION
Because of the way we are doing string-replacement and not AST->AST transformation, we are quite sensitive to the order the transforms run.

In this case, if you rewrite the `->` and the `"#` first, the patcher can't find any original characters to target when it tries to insert the `return`.