### PR TITLE
Ensure bitwise operators have their ranges fixed properly.

### DIFF
--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -46,6 +46,8 @@ export function isConsequentOrAlternate(node) {
  */
 export function isBinaryOperator(node) {
   switch (node.type) {
+    case 'BitAndOp':
+    case 'BitOrOp':
     case 'DivideOp':
     case 'EQOp':
     case 'GTEOp':
@@ -60,6 +62,7 @@ export function isBinaryOperator(node) {
     case 'OfOp':
     case 'PlusOp':
     case 'RemOp':
+    case 'SubtractOp':
       return true;
 
     default:

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -1,0 +1,39 @@
+import check from './support/check';
+
+describe('binary operators', () => {
+  it('passes subtraction through', () => {
+    check(`
+      a - b
+    `, `
+      a - b;
+    `);
+  });
+
+  it('passes bitwise `and` through', () => {
+    check(`
+      a & b
+    `, `
+      a & b;
+    `);
+  });
+
+  it('passes compound subtraction and bitwise `and` through', () => {
+    check(`
+      a - b & c
+      a & b - c
+    `, `
+      a - b & c;
+      a & b - c;
+    `);
+  });
+
+  it('passes compound subtraction and bitwise `or` through', () => {
+    check(`
+      a - b | c
+      a | b - c
+    `, `
+      a - b | c;
+      a | b - c;
+    `);
+  });
+});


### PR DESCRIPTION
Closes #72.

The offending code was `i - 27 & 7`. CoffeeScriptRedux has a bug where nested operators sometimes (always?) don't have proper ranges, so I had to whitelist some more node types as binary operators.

Note that the code in #72 still fails, but for a different reason. I'll submit a separate PR for that issue.

cc @jeffchan @juliankrispel @nickdima