### PR TITLE
Unify block & doc comments.

### DIFF
--- a/src/utils/rangesOfComments.js
+++ b/src/utils/rangesOfComments.js
@@ -12,6 +12,8 @@ const SQUOTE_CODE = 39;
 const BACKWARD_SLASH = 92;
 const FORWARD_SLASH_CODE = 47;
 
+const BLOCK_COMMENT_DELIMITER = '###';
+
 /**
  * Returns the ranges of the sections of source code that are not comments.
  *
@@ -33,9 +35,9 @@ export default function rangesOfComments(source) {
       case NORMAL:
         if (c === HASH_CODE) {
           rangeStart = index;
-          if (source.slice(index, index + 4) === '###\n') {
+          if (source.slice(index, index + BLOCK_COMMENT_DELIMITER.length) === BLOCK_COMMENT_DELIMITER) {
             state = BLOCK_COMMENT;
-            index += 3;
+            index += BLOCK_COMMENT_DELIMITER.length;
           } else {
             state = LINE_COMMENT;
           }
@@ -63,12 +65,8 @@ export default function rangesOfComments(source) {
 
       case BLOCK_COMMENT:
         if (c === HASH_CODE) {
-          if (source.slice(index, index + 4) === '###\n') {
-            index += 3;
-            addComment();
-            state = NORMAL;
-          } else if (source.slice(index, index + 4) === '###' /* EOF */) {
-            index += 3;
+          if (source.slice(index, index + BLOCK_COMMENT_DELIMITER.length) === BLOCK_COMMENT_DELIMITER) {
+            index += BLOCK_COMMENT_DELIMITER.length;
             addComment();
             state = NORMAL;
           }
@@ -116,7 +114,6 @@ export default function rangesOfComments(source) {
     } else {
       type = 'line';
     }
-
     result.push({ start: rangeStart, end: index, type });
   }
 

--- a/test/comment_test.js
+++ b/test/comment_test.js
@@ -11,7 +11,7 @@ describe('comments', () => {
     `);
   });
 
-  it('converts non-doc block comments to /* */', function() {
+  it('converts block comments to /* */', function() {
     check(`
       a(
         ###
@@ -29,7 +29,7 @@ describe('comments', () => {
     `);
   });
 
-  it('converts doc block comments to /** */', function() {
+  it('turns leading hashes on block comment lines to leading asterisks', function() {
     check(`
       a(
         ###
@@ -39,11 +39,35 @@ describe('comments', () => {
       )
     `, `
       a(
-        /**
+        /*
          * HEY
          */
         1
       );
+    `);
+  });
+
+  it('converts mixed doc block comments to /** */', function() {
+    check(`
+      ###*
+      @param {Buffer} un-hashed
+      ###
+      (buffer) ->
+    `, `
+      /**
+      @param {Buffer} un-hashed
+      */
+      (function(buffer) {});
+    `);
+  });
+
+  it('converts single-line block comments to /* */', () => {
+    check(`
+      ### HEX ###
+      a0
+    `, `
+      /* HEX */
+      a0;
     `);
   });
 

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -14,7 +14,7 @@ describe('automatic conversions', function() {
       `, `
         ({
           a: b,
-          /**
+          /*
            * no comma
            */
           c: d


### PR DESCRIPTION
This changes the behavior of block comments such that leading hash marks no longer mark a comment as being a documentation comment. Instead, all block comments are treated equally and users wishing to make a block comment a doc comment simply add an asterisk after the initial `###`.