### PR TITLE
Ensure we handle escape characters when processing strings/regexes.

### DIFF
--- a/src/utils/trimmedNodeRange.js
+++ b/src/utils/trimmedNodeRange.js
@@ -57,19 +57,24 @@ export default function trimmedNodeRange(node, source) {
         break;
 
       case '/':
-          if (state === NORMAL) {
-            // Heuristic to differentiate from division operator
-            if (source.slice(index, index + 3) === '///'
-              || !source.slice(index).match(/^\/=?\s/)) {
-              state = REGEXP;
-            }
-            lastSignificantIndex = index;
-          } else if (state === REGEXP) {
-            state = NORMAL;
-            lastSignificantIndex = index;
-          } else if (state === NORMAL) {
-            lastSignificantIndex = index;
+        if (state === NORMAL) {
+          // Heuristic to differentiate from division operator
+          if (source.slice(index, index + 3) === '///'
+            || !source.slice(index).match(/^\/=?\s/)) {
+            state = REGEXP;
           }
+          lastSignificantIndex = index;
+        } else if (state === REGEXP) {
+          state = NORMAL;
+          lastSignificantIndex = index;
+        } else if (state === NORMAL) {
+          lastSignificantIndex = index;
+        }
+        break;
+
+      case '\\':
+        // The next character is escaped and should not be considered special.
+        index++;
         break;
 
       default:

--- a/test/utils/trimmedNodeRange_test.js
+++ b/test/utils/trimmedNodeRange_test.js
@@ -50,4 +50,12 @@ describe('trimmedNodeRange', function() {
     const nodeRange = trimmedNodeRange(callNode, source);
     deepEqual(nodeRange, [0, 15]);
   });
+
+  it('does not eat into escaped regexes', () => {
+    const source = '"foo".replace(/[a-z\\/]/g, "")';
+    const ast = parse(source);
+    const regexNode = ast.body.statements[0].arguments[0];
+    const nodeRange = trimmedNodeRange(regexNode, source);
+    deepEqual(nodeRange, [14, 24]);
+  });
 });


### PR DESCRIPTION
Mostly this ensures we insert semicolons (or newlines etc) at the right positions, essentially anywhere we would try to trim the node range.

Closes #84.

cc @jeffchan @alexgorbatchev