### PR TITLE
Fix installation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Brian Donovan",
   "license": "MIT",
   "dependencies": {
-    "coffee-script-redux": "https://github.com/michaelficarra/CoffeeScriptRedux.git",
+    "coffee-script-redux": "michaelficarra/CoffeeScriptRedux",
     "detect-indent": "^4.0.0",
     "magic-string": "^0.10.2",
     "repeating": "^2.0.0"


### PR DESCRIPTION
For some reason specifying the full URL fails (npm 2.5.1). Using the NPM-blessed short-syntax works.

```
$ npm install -g decaffeinate
npm ERR! fetch failed https://github.com/michaelficarra/CoffeeScriptRedux.git
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 406
```

More details:
https://github.com/npm/npm/issues/7708